### PR TITLE
Improve pairing script

### DIFF
--- a/pair_q_a.py
+++ b/pair_q_a.py
@@ -1,0 +1,40 @@
+import fitz
+
+PDF = 'Higher-Past-Papers by topic.pdf'
+
+doc = fitz.open(PDF)
+
+pairs = []
+q_pages = []
+started = False
+for i, page in enumerate(doc, start=1):
+    text = page.get_text()
+    lower = text.lower()
+
+    if not started:
+        if 'section 2' in lower and 'marks' in lower:
+            started = True
+        else:
+            continue
+
+    if any(kw in lower for kw in (
+        'for official use', 'candidate', 'instructions for the completion',
+        'data sheet', 'marking instructions')):
+        continue
+
+    if 'additional guidance' in lower:
+        if q_pages:
+            pairs.append((q_pages.copy(), i))
+            q_pages = []
+    else:
+        q_pages.append(i)
+
+# Keep doc open for snippet extraction
+with open('pairs.txt', 'w') as f:
+    for idx, (q, a) in enumerate(pairs, 1):
+        f.write(f"Pair {idx}: Question pages {q} -> Answer page {a}\n")
+        qt = ' '.join(doc.load_page(j-1).get_text().replace('\n',' ')[:80] for j in q)
+        at = doc.load_page(a-1).get_text().replace('\n',' ')[:80]
+        f.write(qt + '\n')
+        f.write('Answer snippet: ' + at + '\n---\n')
+print('Total pairs', len(pairs))

--- a/pairs.txt
+++ b/pairs.txt
@@ -1,0 +1,324 @@
+Pair 1: Question pages [17, 18, 19] -> Answer page 20
+*X75776006* MArKS DO NOT  WRITE IN  THIS  MARGIN Page six SECTION 2 — 110 marks *X75776007* MArKS DO NOT  WRITE IN  THIS  MARGIN Page seven 1. (continued) (a)  *X7577600* MArKS DO NOT  WRITE IN  THIS  MARGIN Page eight  1. (a) (ii)  (cont
+Answer snippet:   Page six      Section 2    Question  Answer  Max  Mark  Additional Guidance  1
+---
+Pair 2: Question pages [22, 23, 24] -> Answer page 26
+*X7577600* MArKS DO NOT  WRITE IN  THIS  MARGIN Page nine  2. A student sets u *X7577600* MArKS DO NOT  WRITE IN  THIS  MARGIN Page ten  2. (continued) (b) T *X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page eleven  2. (b) (continued
+Answer snippet:   Page nine        Question  Answer  Max  Mark  Additional Guidance      (iii)  
+---
+Pair 3: Question pages [27, 29, 30] -> Answer page 31
+*X7577602* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twelve  3. A space probe  *X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page fourteen  4. Light from t *X7577605* MArKS DO NOT  WRITE IN  THIS  MARGIN Page fifteen  4. (b) (continue
+Answer snippet:   Page eleven      Question  Answer  Max  Mark  Additional Guidance  4. (a)    p
+---
+Pair 4: Question pages [32, 33, 35, 36, 37] -> Answer page 39
+*X7577606* MArKS DO NOT  WRITE IN  THIS  MARGIN Page sixteen  5. A quote from  *X7577607* MArKS DO NOT  WRITE IN  THIS  MARGIN Page seventeen  6. (a) The Sta *X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page eighteen  7. The use of a *X75776020* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty  8. A student inve *X7577602* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty-one  8. (continued
+Answer snippet:   Page sixteen      Question  Answer  Max  Mark  Additional Guidance    (d)   Sm
+---
+Pair 5: Question pages [40, 41] -> Answer page 42
+*X75776022* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty-two  9. A student  *X7577602* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty-three  9. (continu
+Answer snippet:   Page seventeen            Question  Answer  Max  Mark  Additional Guidance  9.
+---
+Pair 6: Question pages [44, 45, 46, 47] -> Answer page 49
+*X75776025* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty-five  10. A car ba *X75776026* MArKS DO NOT  WRITE IN  THIS  MARGIN Page twenty-six  10. (continue *X75776027* MArKS DO NOT  WRITE IN  THIS  MARGIN MArKS DO NOT  WRITE IN  THIS   *X7577602* Page twenty-eight MArKS DO NOT  WRITE IN  THIS  MARGIN  10. (b) (co
+Answer snippet:   Page twenty        Question  Answer  Max  Mark  Additional Guidance    (iii) (
+---
+Pair 7: Question pages [50, 51, 52] -> Answer page 53
+MArKS DO NOT  WRITE IN  THIS  MARGIN Page thirty *X7577600*  11. A defibrillat *X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page thirty-one  11. (continue *X7577602* MArKS DO NOT  WRITE IN  THIS  MARGIN Page thirty-two  11. (c) (cont
+Answer snippet:   Page twenty-one      Question  Answer  Max  Mark  Additional Guidance  11. (a)
+---
+Pair 8: Question pages [55, 56, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 73, 74] -> Answer page 75
+*X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page thirty-three  12. A stude *X757760* MArKS DO NOT  WRITE IN  THIS  MARGIN Page thirty-four  12. (continu Page 03 SECTION 1 — 20 marks Attempt ALL questions  1. A car accelerates uniform Page 04  3. A block of wood slides with a constant velocity down a slope. The sl Page 05  5. A planet orbits a star at a distance of 3·0 × 109 m. The star exerts Page 06  7. The graphs show how the radiation per unit surface area, R, varies w Page 07  9. A student makes the following statements about sub-nuclear particles Page 08  11. The table below shows the threshold frequency of radiation for phot Page 09  13. A ray of monochromatic light is incident on a grating as shown. mon Page 10  16. Part of the energy level diagram for an atom is shown X Y E2 E1 E0  Page 11  17. The output of a signal generator is connected to the input of an os Page 12  18. A potential divider circuit is set up as shown. +12 V 0 V 3·0 kΩ 7· Page 13  19. A circuit is set up as shown. 12 V 4·0 Ω A The resistance of the va *X75776006* Page 06 MArKS DO NOT  WRITE IN  THIS  MARGIN SECTION 2 — 110 marks  *X75776007* Page 07 MArKS DO NOT  WRITE IN  THIS  MARGIN 1. (continued) (b) Sho
+Answer snippet: Page 06      Section 2  Question  Answer  Max  Mark  Additional Guidance  1.  (a
+---
+Pair 9: Question pages [76, 77, 78] -> Answer page 79
+*X7577600* Page 08 MArKS DO NOT  WRITE IN  THIS  MARGIN  2. A student uses the *X7577600* Page 09 MArKS DO NOT  WRITE IN  THIS  MARGIN 2. (continued) (b) Det *X7577600* Page 10 MArKS DO NOT  WRITE IN  THIS  MARGIN 2. (c) (continued)  (i
+Answer snippet: Page 07      Question  Answer  Max  Mark  Additional Guidance  2.  (a) (i)  1 31
+---
+Pair 10: Question pages [81, 82, 84, 85] -> Answer page 86
+*X7577602* Page 12 MArKS DO NOT  WRITE IN  THIS  MARGIN  3. The following appa *X757760* Page 13 MArKS DO NOT  WRITE IN  THIS  MARGIN 3. (continued) (c) Sho *X757760* Page 14 MArKS DO NOT  WRITE IN  THIS  MARGIN  4. Two physics studen *X7577605* Page 15 MArKS DO NOT  WRITE IN  THIS  MARGIN 4. (continued) (b) On 
+Answer snippet: Page 10      Question  Answer  Max  Mark  Additional Guidance  4.  (a)   (0·83 +
+---
+Pair 11: Question pages [87, 88, 89] -> Answer page 90
+*X7577606* Page 16  5. (a) A student is using an elastic band to model the exp *X7577607* Page 17 MArKS DO NOT  WRITE IN  THIS  MARGIN 5. (a) (continued)  (i *X757760* Page 18 MArKS DO NOT  WRITE IN  THIS  MARGIN 5. (continued) (b) Whe
+Answer snippet: Page 10      Question  Answer  Max  Mark  Additional Guidance  4.  (a)   (0·83 +
+---
+Pair 12: Question pages [91, 92, 93, 95, 96] -> Answer page 97
+*X757760* Page 19 MArKS DO NOT  WRITE IN  THIS  MARGIN  6. A website states “ *X75776020* Page 20 MArKS DO NOT  WRITE IN  THIS  MARGIN  7. An experiment is s *X7577602* Page 21 MArKS DO NOT  WRITE IN  THIS  MARGIN 7. (continued) (c) The *X75776022* Page 22 MArKS DO NOT  WRITE IN  THIS  MARGIN  8. The diagram shows  *X7577602* Page 23 MArKS DO NOT  WRITE IN  THIS  MARGIN 8. (continued) (c) Mag
+Answer snippet: Page 13      Question  Answer  Max  Mark  Additional Guidance  8.  (a)   mass is
+---
+Pair 13: Question pages [98, 99] -> Answer page 100
+*X7577602* Page 24 MArKS DO NOT  WRITE IN  THIS  MARGIN  9. A student carries  *X75776025* Page 25 MArKS DO NOT  WRITE IN  THIS  MARGIN 9. (continued) (d) The
+Answer snippet: Page 14      Question  Answer  Max  Mark  Additional Guidance  9.  (a)   The wav
+---
+Pair 14: Question pages [101, 102] -> Answer page 103
+*X75776026* Page 26 MArKS DO NOT  WRITE IN  THIS  MARGIN  10. Retroflective mat *X75776027* Page 27 MArKS DO NOT  WRITE IN  THIS  MARGIN 10. (continued) (b) Ca
+Answer snippet: Page 15      Question  Answer  Max  Mark  Additional Guidance  10. (a)    n = si
+---
+Pair 15: Question pages [104, 105, 106, 107] -> Answer page 108
+*X7577602* Page 28 MArKS DO NOT  WRITE IN  THIS  MARGIN  11. A student is desc *X7577602* Page 29 MArKS DO NOT  WRITE IN  THIS  MARGIN  12. A technician sets *X7577600* Page 30 MArKS DO NOT  WRITE IN  THIS  MARGIN 12. (continued) (b) So *X757760* Page 31 MArKS DO NOT  WRITE IN  THIS  MARGIN 12. (b) (continued)  (
+Answer snippet: Page 17      Question  Answer  Max  Mark  Additional Guidance  12. (a) (i)  V IR
+---
+Pair 16: Question pages [110, 111, 113, 114, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 130, 131] -> Answer page 132
+*X7577602* Page 32 MArKS DO NOT  WRITE IN  THIS  MARGIN  13. A technician sets *X757760* Page 33 MArKS DO NOT  WRITE IN  THIS  MARGIN 13. (continued) (b) Th *X757760* Page 34 MArKS DO NOT  WRITE IN  THIS  MARGIN  14. A student investi *X7577605* Page 35 MArKS DO NOT  WRITE IN  THIS  MARGIN 14. (continued) (b) Th Page 03 SECTION 1 — 20 marks Attempt ALL questions  1. The graph shows how the v Page 04  3. The graph shows how the vertical speed of a skydiver varies with tim Page 05  5. A galaxy has a recessional velocity of 0·30c. Hubble’s Law predicts  Page 06  8. The following statement represents a nuclear reaction. Lr Z He 256 4 Page 07  10. Ultraviolet radiation of frequency 7·70 × 1014 Hz is incident on th Page 08  12. A ray of red light passes from a liquid to a transparent solid. The Page 09  14. A student carries out an experiment to investigate how irradiance v Page 10  16. The output from an a.c. power supply is connected to an oscilloscop Page 11  18. A circuit containing a capacitor is set up as shown. 6∙0 V 480 Ω 12 Page 12  20. Astronomers use the following relationship to determine the distanc *X75776006* Page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN SECTION 2 — 110 marks  *X75776007* Page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  1.  (continued) (b) L
+Answer snippet: Page 06    Section 2  Question  Answer  Max  mark  Additional guidance  1.  (a) 
+---
+Pair 17: Question pages [133, 134] -> Answer page 135
+*X7577600* Page 08 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. A white snooker ba *X7577600* Page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  2.  (continued) (b) A
+Answer snippet: Page 07    Question  Answer  Max  mark  Additional guidance  2.  (a) (i)  (total
+---
+Pair 18: Question pages [136, 137] -> Answer page 139
+*X7577600* Page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. A ball is thrown v *X757760* Page 11 MARKS DO NOT  WRITE IN  THIS  MARGIN  3.  (a) (continued)  
+Answer snippet: Page 09    Question  Answer  Max  mark  Additional guidance  3.  (a) (ii) v u as
+---
+Pair 19: Question pages [140, 141, 142, 144] -> Answer page 145
+*X7577602* Page 12 MARKS DO NOT  WRITE IN  THIS  MARGIN  4.  Some motorways ha *X757760* Page 14 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. Planets outside ou *X7577605* Page 15 MARKS DO NOT  WRITE IN  THIS  MARGIN  5.  (continued) (b) T *X7577606* Page 16 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. The visible spectr
+Answer snippet: Page 12    Question  Answer  Max  mark  Additional guidance  6.  (a)   E0 to E3 
+---
+Pair 20: Question pages [146, 147] -> Answer page 148
+*X757760* Page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. The following diag *X757760* Page 19 MARKS DO NOT  WRITE IN  THIS  MARGIN  7.  (continued) (c)  
+Answer snippet: Page 13    Question  Answer  Max  mark  Additional guidance  7.  (a)   They are 
+---
+Pair 21: Question pages [149, 150, 152, 153] -> Answer page 154
+*X75776020* Page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. X-ray machines are *X7577602* Page 21 MARKS DO NOT  WRITE IN  THIS  MARGIN  8.  (continued) (b) T *X75776022* Page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. A diagram from a ' *X7577602* Page 23 MARKS DO NOT  WRITE IN  THIS  MARGIN  9.  (continued) (b) T
+Answer snippet: Page 15    Question  Answer  Max  mark  Additional guidance  9.  (a)   (Two) sma
+---
+Pair 22: Question pages [156, 157, 159, 160, 161] -> Answer page 162
+*X7577602* Page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. An experiment is  *X75776025* Page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (b) (continued)   *X75776026* Page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. The use of analog *X7577602* Page 28 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. A lamp is connect *X7577602* Page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN  12.  (continued) (c) 
+Answer snippet: Page 19    Question  Answer  Max  mark  Additional guidance  12. (a)    1·5 J (o
+---
+Pair 23: Question pages [164] -> Answer page 165
+*X757760* Page 31 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. An uncharged 220 
+Answer snippet: Page 21    Question  Answer  Max  mark  Additional guidance  13. (a)    V = IR  
+---
+Pair 24: Question pages [166, 167] -> Answer page 168
+*X7577602* Page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. Solar cells are m *X757760* Page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  14.  (b) (continued) 
+Answer snippet: Page 21    Question  Answer  Max  mark  Additional guidance  13. (a)    V = IR  
+---
+Pair 25: Question pages [169, 170, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 188, 189] -> Answer page 190
+*X757760* Page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. A wire of length  *X7577605* Page 35 MARKS DO NOT  WRITE IN  THIS  MARGIN  15.  (continued) (b)  page 03 SECTION 1 — 20 marks Attempt ALL questions  1. A car is moving at a spee page 04  3. A block of mass 6·0 kg and a block of mass 8·0 kg are connected by a page 05  6. A spacecraft is travelling at 0·10c relative to a star. An observer  page 06  10. A proton enters a region of magnetic field as shown. region of  mag page 07  13. Waves from two coherent sources, S1 and S2, produce an interference page 08  14. A ray of monochromatic light passes from air into a block of glass  page 09  15. A circuit is set up as shown. V 10 Ω 10 Ω 10 Ω S A1 A2 12 V The bat page 10  17. A 24·0 μF capacitor is charged until the potential difference acros page 11  19. The circuit shown is used to charge and then discharge a capacitor  page 12  20. A student carries out an experiment to determine the specific heat  *X75776006* page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN SECTION 2 — 110 marks  *X75776007* page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (a) (continued)  (
+Answer snippet:   page 06      Section 2    Question  Answer  Max  mark  Additional guidance  1.
+---
+Pair 26: Question pages [192, 193, 194] -> Answer page 195
+*X7577600* page 08 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. An internet shoppi *X7577600* page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. (a) (continued)  ( *X7577600* page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. (continued) (b) To
+Answer snippet:   page 08      Question  Answer  Max  mark  Additional guidance  2.  (a)  (i)  =
+---
+Pair 27: Question pages [197, 198, 199, 201, 202, 203] -> Answer page 204
+*X7577602* page 12 DO NOT  WRITE IN  THIS  MARGIN  3. A student sets up an exp *X757760* page 13 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (a) Sh *X757760* page 14 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (c) Ex *X7577605* page 15 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. A stunt is being c *X7577606* page 16 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. Hubble’s Law state *X7577607* page 17 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (b) (continued)  (
+Answer snippet:   page 12      Question  Answer  Max  mark  Additional guidance  5.  (a)    Cosm
+---
+Pair 28: Question pages [206, 207, 208] -> Answer page 209
+*X757760* page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. An experiment is s *X757760* page 19 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (b) As *X75776020* page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (c) A 
+Answer snippet:   page 14      Question  Answer  Max  mark  Additional guidance  6.  (a)  (i)   
+---
+Pair 29: Question pages [210, 211, 212] -> Answer page 213
+*X75776022* page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. A student uses a g *X7577602* page 23 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (b) Th *X7577602* page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (c) Th
+Answer snippet:   page 16      Question  Answer  Max  mark  Additional guidance  7.  (a)    Freq
+---
+Pair 30: Question pages [214, 215, 216, 218, 219, 220] -> Answer page 221
+*X75776025* page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. A student investig *X75776026* page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (a) (continued)  ( *X75776027* page 27 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (Continued) (b) Th *X7577602* page 28 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. A ray of monochrom *X7577602* page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (b) (continued)  ( *X7577600* page 30 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (continued) (c) A 
+Answer snippet:   page 18      Question  Answer  Max  mark  Additional guidance  9.  (a)    sin 
+---
+Pair 31: Question pages [223, 224, 225] -> Answer page 226
+*X757760* page 31 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. In a laboratory e *X7577602* page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (b) S *X757760* page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (c) I
+Answer snippet:   page 20      Question  Answer  Max  mark  Additional guidance  10. (a)    A (c
+---
+Pair 32: Question pages [228, 229, 230] -> Answer page 231
+*X757760* page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. A student constru *X7577605* page 35 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (continued) (b) T *X7577606* page 36 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (continued) (c) T
+Answer snippet:   page 22        Question  Answer  Max  mark  Additional guidance  11. (a)    Th
+---
+Pair 33: Question pages [232, 233, 234] -> Answer page 235
+*X757760* page 38 DO NOT  WRITE IN  THIS  MARGIN  12. A student carries out a *X757760* page 39 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (a) (continued)   *X7577600* page 40 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (continued) (b) T
+Answer snippet:   page 23        Question  Answer  Max  mark  Additional guidance  12. (a)  (i) 
+---
+Pair 34: Question pages [237, 238, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 260, 261, 262, 264] -> Answer page 265
+*X757760* page 41 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. A student sets up *X7577602* page 42  13. (continued) (b) The student repeats the experiment wit page 03 Total marks — 25 Attempt ALL questions  1. The following velocity-time g page 04  2. A train accelerates uniformly from 5·0 m s−1 to 12·0 m s−1 while tra page 05  4. A block of wood slides with a constant velocity down a slope. The sl page 06  6. The graph shows the force that acts on an object over a time interva page 07  8. Two small asteroids are 12 m apart. The masses of the asteroids are  page 08  10. The siren on an ambulance is emitting sound with a constant frequen page 09  13. The electric field patterns around charged particles Q, R and S are page 10  14. A student makes the following statements about an electron.  I  An  page 11  16. /LJKW IURP D SRLQW VRXUFH LV LQFLGHQW RQ D VFUHHQ 7KH  page 12  18. In an atom, a photon is emitted when an electron makes a transition page 13  20. The rms voltage of the mains supply is 230 V. The approximate value page 14  22. In the diagrams below, each resistor has the same resistance. Which page 15  24. The EMF of a battery is A  the total energy supplied by the battery *S857760103* page 03 MARKS DO NOT  WRITE IN  THIS  MARGIN Total marks — 130 Atte *S857760104* page 04 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (c) Th *S857760105* page 05 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (d) Th *S857760106* page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. When a car brakes 
+Answer snippet: page 06  Question  Expected response  Max  mark  Additional guidance  2.      Es
+---
+Pair 35: Question pages [266, 267, 268] -> Answer page 269
+*S857760107* page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (a) A gymnast of m *S857760108* page 08 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (a) (continued)  ( *S857760109* page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (b) An
+Answer snippet: page 07  Question  Expected response  Max  mark  Additional guidance  3.  (a)  (
+---
+Pair 36: Question pages [270, 271] -> Answer page 272
+*S857760110* page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. Muons are sub-atom *S857760111* page 11 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. (continued) (c) Ex
+Answer snippet: page 08  Question  Expected response  Max  mark  Additional guidance  4.  (a)   
+---
+Pair 37: Question pages [273, 274] -> Answer page 275
+*S857760112* page 12 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (a) The diagram be *S857760113* page 13 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (continued) (b) Th
+Answer snippet: page 09  Question  Expected response  Max  mark  Additional guidance  5.  (a)  (
+---
+Pair 38: Question pages [276, 277] -> Answer page 278
+*S857760114* page 14 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. A linear accelerat *S857760115* page 15 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (b)  (
+Answer snippet: page 11  Question  Expected response  Max  mark  Additional guidance  6.  (a)  (
+---
+Pair 39: Question pages [279, 280] -> Answer page 281
+*S857760116* page 16 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. The following diag *S857760117* page 17 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (c) Ex
+Answer snippet: page 12  Question  Expected response  Max  mark  Additional guidance  7.  (a)   
+---
+Pair 40: Question pages [282, 283] -> Answer page 284
+*S857760118* page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. The following stat *S857760119* page 19 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (continued) (b) Ca
+Answer snippet: page 13  Question  Expected response  Max  mark  Additional guidance  8.  (a)   
+---
+Pair 41: Question pages [285, 286] -> Answer page 287
+*S857760120* page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. A student carries  *S857760121* page 21 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (continued) (c) Su
+Answer snippet: page 14  Question  Expected response  Max  mark  Additional guidance  9.  (a)   
+---
+Pair 42: Question pages [288, 289, 290] -> Answer page 291
+*S857760122* page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. A metal plate emi *S857760123* page 23 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (b) T *S857760124* page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (c) T
+Answer snippet: page 15  Question  Expected response  Max  mark  Additional guidance  10. (a)  (
+---
+Pair 43: Question pages [292, 293, 294] -> Answer page 295
+*S857760125* page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. A helium-neon las *S857760126* page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (continued) (b) T *S857760127* page 27 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (b) (continued)  
+Answer snippet: page 17  Question  Expected response  Max  mark  Additional guidance  11. (a)   
+---
+Pair 44: Question pages [296] -> Answer page 297
+*S857760128* page 28 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. A technician inve
+Answer snippet: page 18  Question  Expected response  Max  mark  Additional guidance  12. (a)   
+---
+Pair 45: Question pages [298, 299] -> Answer page 300
+*S857760129* page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN [Turn over  13. The fo *S857760130* page 30 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. (continued) (a) U
+Answer snippet: page 19  Question  Expected response  Max  mark  Additional guidance  13. (a)  (
+---
+Pair 46: Question pages [301, 302] -> Answer page 303
+*S857760131* page 31 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. A 220 µF capacito *S857760132* page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. (b) (continued)  
+Answer snippet: page 20  Question  Expected response  Max  mark  Additional guidance  14. (a)   
+---
+Pair 47: Question pages [304, 305, 307, 308, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 327, 328, 329, 330] -> Answer page 331
+*S857760133* page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. The electrical co *S857760134* page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. (continued) (b) A *S857760135* page 35 MARKS DO NOT  WRITE IN  THIS  MARGIN  16. A group of studen *S857760136* page 36 MARKS DO NOT  WRITE IN  THIS  MARGIN  16. (continued) (b) F page 03 Total mark — 25 Attempt ALL questions  1. The graph shows how the speed  page 04  3. A golfer strikes a golf ball, which then moves off at an angle to th page 05  4. A car accelerates from rest along a straight level road. The acceler page 06  5. Four masses on a horizontal, frictionless surface are linked togethe page 07  7. The terminal velocity vt of a skydiver is given by the relationship  page 08  9. The redshift of a distant galaxy is 0·014. According to Hubble’s law page 09  11. An alpha particle is accelerated in an electric field between metal page 10  12. An electron enters a region of uniform magnetic field as shown. reg page 11  13. A student makes the following statements about the Standard Model.  page 12  15. The diagram shows an experiment set up to investigate the photoelec page 13  16. A photon of energy 6·40 × 10-19 J is incident on a metal plate. Thi page 14  18. A ray of monochromatic light passes from air into water. The wavele page 15  20. The output from an AC power supply is connected to an oscilloscope. page 16  21. The output from a signal generator is connected to an oscilloscope. page 17  22. A student sets up a circuit and measures the voltage across and the page 18  24. A student connects four identical light emitting diodes (LEDs) to a *X857761* page 04 DO NOT  WRITE IN  THIS  MARGIN Total marks — 130 Attempt AL *X8577615* page 05 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (a) Us *X8577616* page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (b) Th *X8577617* page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (c) Co
+Answer snippet: page 05    (1)  (1)  Question  Expected response  Max  mark  Additional guidance
+---
+Pair 48: Question pages [334, 335] -> Answer page 336
+*X8577618* page 08 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. A student abseils  *X857761* page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. (continued) (b) De
+Answer snippet: page 08    Question  Expected response  Max  mark  Additional guidance  2.  (a) 
+---
+Pair 49: Question pages [337, 338, 339] -> Answer page 340
+*X8577611* page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. A footballer tells *X85776112* page 12 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. A commXnications s *X8577611* page 13 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. (continued) (c) De
+Answer snippet: page 10    (1)  (1)  Question  Expected response  Max  mark  Additional guidance
+---
+Pair 50: Question pages [341, 342] -> Answer page 343
+*X8577611* page 14 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (a) A person is st *X85776115* page 15 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (continued) (b) Th
+Answer snippet: page 11    Question  Expected response  Max  mark  Additional guidance  5.  (a) 
+---
+Pair 51: Question pages [344, 345] -> Answer page 346
+*X85776116* page 16 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. Stars emit radiati *X85776117* page 17 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (b) Th
+Answer snippet: page 12    Question  Expected response  Max  mark  Additional guidance  6.  (a) 
+---
+Pair 52: Question pages [347, 348, 349] -> Answer page 350
+*X85776118* page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. Scientists have re *X8577611* page 19 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (c) On *X8577612* page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (d) Th
+Answer snippet: page 13    Question  Expected response  Max  mark  Additional guidance  7.  (a) 
+---
+Pair 53: Question pages [351, 352] -> Answer page 353
+*X85776122* page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. The Sun emits ener *X8577612* page 23 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (continued) (c) De
+Answer snippet: page 14    Question  Expected response  Max  mark  Additional guidance  8.  (a) 
+---
+Pair 54: Question pages [354, 355] -> Answer page 356
+*X8577612* page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. A laser emits ligh *X85776125* page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (a) (continued)  (
+Answer snippet: page 15    Question  Expected response  Max  mark  Additional guidance  9.  (a) 
+---
+Pair 55: Question pages [358, 359] -> Answer page 361
+*X85776126* page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. A student carries *X85776127* page 27 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (b) T
+Answer snippet: page 18    (1)    (1)    (1)  (1)    (1)      (1)  Question  Expected response  
+---
+Pair 56: Question pages [362, 363] -> Answer page 364
+*X85776128* page 28 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. Diamonds sparkle  *X8577612* page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (continued) (c) M
+Answer snippet: page 18    (1)    (1)    (1)  (1)    (1)      (1)  Question  Expected response  
+---
+Pair 57: Question pages [365, 366] -> Answer page 367
+*X857761* page 30 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (a) A student set *X8577611* page 31 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (continued) (b) A
+Answer snippet: page 19    Question  Expected response  Max  mark  Additional guidance  12. (a) 
+---
+Pair 58: Question pages [368, 369] -> Answer page 370
+*X8577612* page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. A student investi *X857761* page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. (continued) (b) T
+Answer snippet: page 20    Question  Expected response  Max  mark  Additional guidance  13. (a) 
+---
+Pair 59: Question pages [371, 372, 373] -> Answer page 374
+*X857761* page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. (continued) (d) T *X8577616* page 36 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. Solids can be cat *X8577617* page 37 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. (continued) (b) U
+Answer snippet: page 22    Question  Expected response  Max  mark  Additional guidance  14. (a) 
+---
+Pair 60: Question pages [375, 376, 377, 378, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 398, 399, 401, 402] -> Answer page 403
+*X857761* page 39 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. A 1·00 m long woo *X857761* page 40 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. (continued) (b) T *X8577611* page 41 [Turn over for next question Back to Table Page 68 Back to  *X8577612* page 42 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. (continued) (c) T page 03 Total marks — 25 Attempt ALL questions  1. A specially adapted ball has  page 04  2. The velocity-time (v-t) graph for an object travelling in a straight page 05  3. The velocity-time (v-t) graph for an object travelling along a strai page 06  5. Two objects, P and Q, of the same mass are dropped from the same hei page 07  7. A carpenter is building a doorframe using a nail gun. The nail gun o page 08  10. A spacecraft is travelling at a speed of 0·45c relative to Earth. A page 09  13. Which of the following diagrams represents the electric field betwe page 10  14. The group of matter particles known as fermions consists of A  bary page 11  17. An experiment to demonstrate the photoelectric effect is set up as  page 12  18. Two identical loudspeakers are connected to a signal generator as s page 13  20. The diagram shows the path of three rays of red light P, Q and R in page 14  22. A resistor of resistance 100 Ω is rated at 4 W. The maximum voltage page 15  25. A circuit is set up as shown. S C R A Capacitor C is initially unch *X857761* page 04 MARKS DO NOT  WRITE IN  THIS  MARGIN Total marks — 130 Atte *X8577615* page 05 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (continued) (b) Ca *X8577616* page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. A train consists o *X8577617* page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. (continued) (b) La
+Answer snippet: page 06    Question  Expected response  Max  mark  Additional guidance  2.   (a)
+---
+Pair 61: Question pages [404, 405] -> Answer page 406
+*X8577618* page 08 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. A manufacturer tes *X857761* page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (b) Th
+Answer snippet: page 07    Question  Expected response  Max  mark  Additional guidance  3.  (a) 
+---
+Pair 62: Question pages [407, 408, 409, 410] -> Answer page 411
+*X8577611* page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. A student finds th *X85776112* page 12 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. Astronomers have r *X8577611* page 13 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (continued) (b) An *X8577611* page 14 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (b) (continued)  (
+Answer snippet: page 09    Question  Expected response  Max  mark  Additional guidance  5.  (a) 
+---
+Pair 63: Question pages [412, 413, 414] -> Answer page 415
+*X85776116* page 16 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. White light from t *X85776117* page 17 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (a) (continued)  ( *X85776118* page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (b) Th
+Answer snippet: page 10    Question  Expected response  Max  mark  Additional guidance  6.  (a) 
+---
+Pair 64: Question pages [416, 417, 418] -> Answer page 419
+*X8577611* page 19 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. The Large Hadron C *X8577612* page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (b) Li *X85776121* page 21 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (d) In
+Answer snippet: page 11    Question  Expected response  Max  mark  Additional guidance  7.  (a) 
+---
+Pair 65: Question pages [420, 421] -> Answer page 422
+*X85776122* page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. A student investig *X8577612* page 23 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (b) (continued)  (
+Answer snippet: page 12    Question  Expected response  Max  mark  Additional guidance  8.  (a) 
+---
+Pair 66: Question pages [423, 424, 425, 426] -> Answer page 427
+*X8577612* page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. Dental braces are  *X85776125* page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (continued) (b) Li *X85776126* page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (b) (continued)  ( *X85776127* page 27 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (b) (continued)  (
+Answer snippet: page 13    Question  Expected response  Max  mark  Additional guidance  9.  (a) 
+---
+Pair 67: Question pages [428, 429, 430] -> Answer page 431
+page 14        (B)                 (Voltage applied causes) electrons to  move f *X85776128* page 28 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. A technician carr *X8577612* page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (a) (continued)  
+Answer snippet: page 15    Question  Expected response  Max  mark  Additional guidance  10. (a) 
+---
+Pair 68: Question pages [432, 433, 434] -> Answer page 435
+*X857761* page 30 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. The use of analog *X8577612* page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. A technician fill *X857761* page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (continued) (b) T
+Answer snippet: page 17    Question  Expected response  Max  mark  Additional guidance  12.  (a)
+---
+Pair 69: Question pages [436, 437] -> Answer page 438
+*X857761* page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. A student connect *X8577615* page 35 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. (b) (continued)  
+Answer snippet: page 18    Question  Expected response  Max  mark  Additional guidance  13. (a) 
+---
+Pair 70: Question pages [439, 440, 441] -> Answer page 442
+*X8577616* page 36 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. A student carries *X8577617* page 37 MARKS DO NOT  WRITE IN  THIS  MARGIN   14. (continued) (b)  *X8577618* page 38 MARKS DO NOT  WRITE IN  THIS  MARGIN  14. (continued) (c) T
+Answer snippet: page 19    Question  Expected response  Max  mark  Additional guidance  14. (a) 
+---
+Pair 71: Question pages [443, 444, 445, 446, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 468, 469] -> Answer page 471
+*X857761* page 39 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. A student carries *X857761* page 40 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. (continued) (b) T *X8577611* page 41 MARKS DO NOT  WRITE IN  THIS  MARGIN  15. (b) (continued)   *X8577612* page 42 Back to Table Page 67 Back to Table  page 03 Total marks — 25  Attempt ALL questions  1. A ball is thrown vertically  page 04  2. A student uses the apparatus shown to determine the acceleration of  page 05  3. A spacecraft unloads cargo on the surface of the Moon. The gravitati page 06  4. Two blocks are suspended from a ceiling by ropes as shown. X 12 kg Y page 07  5. During an experiment a student inside a lift stands on a newton bala page 08  7. A spacecraft passes the Earth at a speed of 0.4c. A light on the spa page 09  10. A proton enters a region of magnetic field as shown. proton region  page 10  12. A proton consists of two up quarks and a down quark. A student make page 11  14. The following statement represents a nuclear reaction. 240 236 4 94 page 12  16. Light from a laser is incident on a grating as shown. laser light g page 13  17. Which row in the table shows what happens to the speed, frequency,  page 14  19. Three resistors are connected to a 3.0 V power supply as shown. +3. page 15  21. A circuit is set up as shown. 12 V 4.0 Ω A The resistance of the va page 16  23. A circuit is set up as shown. S R C VR VC A The capacitor is initia page 17  24. Which row in the table describes the conduction band and the gap be *X857760104* page 04 MARKS DO NOT  WRITE IN  THIS  MARGIN Total marks — 130 Atte *X857760105* page 05 MARKS DO NOT  WRITE IN  THIS  MARGIN  1. (a) (continued)  (
+Answer snippet: page 06  Question  Expected response  Max  mark  Additional guidance  (iii) s ut
+---
+Pair 72: Question pages [472, 473] -> Answer page 474
+*X857760106* page 06 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. A student carries  *X857760107* page 07 MARKS DO NOT  WRITE IN  THIS  MARGIN  2. (a) (continued)  (
+Answer snippet: page 07  Question  Expected response  Max  mark  Additional guidance  2.  (a)  (
+---
+Pair 73: Question pages [475, 476, 477] -> Answer page 478
+*X857760108* page 08 DO NOT  WRITE IN  THIS  MARGIN  3. A student sets up an exp *X857760109* page 09 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (a)  ( *X857760110* page 10 MARKS DO NOT  WRITE IN  THIS  MARGIN  3. (continued) (c) Ex
+Answer snippet:   page 08      Question  Expected response  Max  mark  Additional guidance  3.  
+---
+Pair 74: Question pages [481, 482, 483, 484, 485] -> Answer page 486
+*X857760112* page 12 MARKS DO NOT  WRITE IN  THIS  MARGIN  4. In 2012, a record  *X857760115* page 15 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. A teacher uses a b *X857760116* page 16 DO NOT  WRITE IN  THIS  MARGIN  5. (continued) (b) The teac *X857760117* page 17 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (b) (continued)  ( *X857760118* page 18 MARKS DO NOT  WRITE IN  THIS  MARGIN  5. (continued) (c)  (
+Answer snippet:   page 12      Question  Expected response  Max  mark  Additional guidance  5.  
+---
+Pair 75: Question pages [487, 488, 489] -> Answer page 490
+*X857760120* page 20 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. The Standard Model *X857760121* page 21 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (c) An *X857760122* page 22 MARKS DO NOT  WRITE IN  THIS  MARGIN  6. (continued) (d) Pi
+Answer snippet:   page 13      Question  Expected response  Max  mark  Additional guidance  6.  
+---
+Pair 76: Question pages [491, 492, 493] -> Answer page 494
+*X857760124* page 24 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. Protons are accele *X857760125* page 25 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (b) (continued)  ( *X857760126* page 26 MARKS DO NOT  WRITE IN  THIS  MARGIN  7. (continued) (c) Th
+Answer snippet:   page 15      Question  Expected response  Max  mark  Additional guidance  7.  
+---
+Pair 77: Question pages [495, 496, 497, 498] -> Answer page 499
+*X857760128* page 28 DO NOT  WRITE IN  THIS  MARGIN  8. A student investigates l *X857760129* page 29 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (a) (continued)  ( *X857760130* page 30 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (continued) (b) Th *X857760131* page 31 MARKS DO NOT  WRITE IN  THIS  MARGIN  8. (b) (continued)  (
+Answer snippet:   page 16      Question  Expected response  Max  mark  Additional guidance  8.  
+---
+Pair 78: Question pages [501, 502, 504, 505] -> Answer page 506
+*X857760132* page 32 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. The apparatus show *X857760133* page 33 MARKS DO NOT  WRITE IN  THIS  MARGIN  9. (continued) (b) Th *X857760134* page 34 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. A student is carr *X857760135* page 35 MARKS DO NOT  WRITE IN  THIS  MARGIN  10. (continued) (c) T
+Answer snippet:   page 19      Question  Expected response  Max  mark  Additional guidance  10. 
+---
+Pair 79: Question pages [507, 508] -> Answer page 509
+*X857760136* page 36 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. A triangular pris *X857760137* page 37 MARKS DO NOT  WRITE IN  THIS  MARGIN  11. (continued) (c) T
+Answer snippet:   page 20      Question  Expected response  Max  mark  Additional guidance  11. 
+---
+Pair 80: Question pages [510, 511, 512] -> Answer page 513
+*X857760138* page 38 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. A student uses th *X857760139* page 39 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (continued) (b) U *X857760140* page 40 MARKS DO NOT  WRITE IN  THIS  MARGIN  12. (continued) (e) T
+Answer snippet:   page 21      Question  Expected response  Max  mark  Additional guidance  12. 
+---
+Pair 81: Question pages [514, 515] -> Answer page 516
+*X857760142* page 42 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. A student carries *X857760143* page 43 MARKS DO NOT  WRITE IN  THIS  MARGIN  13. (b) (continued)  
+Answer snippet:   page 22      Question  Expected response  Max  mark  Additional guidance  13. 
+---


### PR DESCRIPTION
## Summary
- refine `pair_q_a.py` to skip introduction pages and only stop when an answer page is detected
- regenerate `pairs.txt` using the updated logic

## Testing
- `python3 pair_q_a.py`
- `python3 generate_index.py --max-pages 2`

------
https://chatgpt.com/codex/tasks/task_e_68656e22ec588321b7aa4962b8911d94